### PR TITLE
Clear context to SchedulePickerView

### DIFF
--- a/neon/View/Schedule/Sheets/SchedulePickerView.swift
+++ b/neon/View/Schedule/Sheets/SchedulePickerView.swift
@@ -39,7 +39,12 @@ struct SchedulePickerView: View {
             CardsListView {
                 ForEach(viewModel.todaysHourBlocks.filter { $0.hourBlock.hour >= (viewModel.currentDate.isToday ?  viewModel.currentHour : UtilGateway.shared.dayStartHour()) }) { hourBlockViewModel in
                     if hourBlockViewModel.getTitle() != AppStrings.Schedule.HourBlock.empty {
-                        CompactHourBlockView(viewModel: hourBlockViewModel)
+                      CompactHourBlockView(viewModel: hourBlockViewModel)
+                        .contextMenu(ContextMenu(menuItems: {
+                          Button(action: { viewModel.clearBlock(hourBlockViewModel.hourBlock) }) {
+                              Label(AppStrings.ToDoList.ToDoItem.menuClear, systemImage: AppStrings.Icons.clear)
+                          }
+                      }))
                     } else {
                         PickerEmptyBlockView(viewModel: hourBlockViewModel,
                                              hourBlock: hourBlock,

--- a/neon/View/Schedule/Sheets/SchedulePickerView.swift
+++ b/neon/View/Schedule/Sheets/SchedulePickerView.swift
@@ -40,11 +40,11 @@ struct SchedulePickerView: View {
                 ForEach(viewModel.todaysHourBlocks.filter { $0.hourBlock.hour >= (viewModel.currentDate.isToday ?  viewModel.currentHour : UtilGateway.shared.dayStartHour()) }) { hourBlockViewModel in
                     if hourBlockViewModel.getTitle() != AppStrings.Schedule.HourBlock.empty {
                       CompactHourBlockView(viewModel: hourBlockViewModel)
-                        .contextMenu(ContextMenu(menuItems: {
-                          Button(action: { viewModel.clearBlock(hourBlockViewModel.hourBlock) }) {
-                              Label(AppStrings.ToDoList.ToDoItem.menuClear, systemImage: AppStrings.Icons.clear)
-                          }
-                      }))
+                        .contextMenu {
+                            Button(action: { viewModel.clearBlock(hourBlockViewModel.hourBlock) }) {
+                                Label(AppStrings.ToDoList.ToDoItem.menuClear, systemImage: AppStrings.Icons.clear)
+                            }
+                        }
                     } else {
                         PickerEmptyBlockView(viewModel: hourBlockViewModel,
                                              hourBlock: hourBlock,


### PR DESCRIPTION
Hey @jtsaeed!

I was researching app sources and playing a little with code, then I've found out that there is no way to remove an item from SchedulePickerView. The only way is to go back to Schedule and remove the item here. So I've added a context menu with a Clear button. Screenshot is attached

![image](https://user-images.githubusercontent.com/24964748/115089167-5e00aa00-9f1a-11eb-9dbf-71e3b283b63d.png)
